### PR TITLE
Delete async

### DIFF
--- a/benchmark/deleting_records.coffee
+++ b/benchmark/deleting_records.coffee
@@ -26,6 +26,12 @@ suite.add "deleting mongraph documents", (deferred) ->
     deferred.resolve()
 , defer: true
 
+suite.add "deleting mongraph documents + nodes async", (deferred) ->
+  bar = new Location(value: Math.random())
+  bar.save (err, document) -> bar.removeWithGraph async: false, (err) ->
+    deferred.resolve()
+, defer: true
+
 suite.on "cycle", (event) ->
   console.log "* "+String(event.target)
 

--- a/src/mongraphMongoosePlugin.coffee
+++ b/src/mongraphMongoosePlugin.coffee
@@ -30,12 +30,7 @@ module.exports = exports = mongraphMongoosePlugin = (schema, options = {}) ->
 
   if schemaOptions.graphability.middleware.preRemove
     schema.pre 'remove', (errHandler, next) ->
-      # skip remove node if no node id is set
-      return next(null) unless @._node_id > 0
-      # Remove also all relationships
-      opts =
-        includeRelationships: schemaOptions.graphability.relationships.removeAllOutgoing and schemaOptions.graphability.relationships.removeAllOutgoing
-      @removeNode opts, next
+      @removeWithGraph next
 
   if schemaOptions.graphability.middleware.preSave
     schema.pre 'save', true, (next, done) ->

--- a/test/tests.coffee
+++ b/test/tests.coffee
@@ -321,22 +321,22 @@ describe "Mongraph", ->
                   node.delete ->
                     return doneNoDeleteHook()
 
-          # doneNoSaveHook   = join.add()
-          # schema   = new mongoose.Schema name: String
-          # schema.set 'graphability', middleware: preSave: false
-          # # explicit overriding middleware
-          # schema.pre 'save', (next) ->
-          #   calledPreSave = true
-          #   next()
+          doneNoSaveHook   = join.add()
+          schema   = new mongoose.Schema name: String
+          schema.set 'graphability', middleware: preSave: false
+          # explicit overriding middleware
+          schema.pre 'save', (next) ->
+            calledPreSave = true
+            next()
           
-          # Drumkit  = mongoose.model "Drumkit",  schema
-          # drums    = new Drumkit name: 'Tama'
-          # drums.save (err, doc) ->
-          #   expect(err).to.be null
-          #   expect(calledPreSave).to.be true
-          #   expect(doc._cached_node).not.be.an 'object'
-          #   drums.remove ->
-          #     doneNoSaveHook()
+          Drumkit  = mongoose.model "Drumkit",  schema
+          drums    = new Drumkit name: 'Tama'
+          drums.save (err, doc) ->
+            expect(err).to.be null
+            expect(calledPreSave).to.be true
+            expect(doc._cached_node).not.be.an 'object'
+            drums.remove ->
+              doneNoSaveHook()
 
           join.when ->
             done()
@@ -567,6 +567,17 @@ describe "Mongraph", ->
                   expect(likes).to.be null
                   frank.remove() if cleanupNodes
                   done()
+
+    describe '#removeWithGraph', ->
+
+      it 'expect to remove document and node async', (done) ->
+        frank  = new Person name: 'frank'
+        frank.removeWithGraph async: true, (err) ->
+          expect(err).to.be null
+          # we set a timeout because we deleted the node async
+          # and don't want to get an error because of nodes count mismatch
+          setTimeout done, 50
+
 
     describe '#shortestPath()', ->
 


### PR DESCRIPTION
implemented, but no performance gain...

```
### DELETING RECORDS

* deleting native mongodb documents x 692 ops/sec ±3.73% (70 runs sampled)
* deleting mongoose documents x 443 ops/sec ±1.82% (81 runs sampled)
* deleting neo4j nodes x 153 ops/sec ±20.82% (63 runs sampled)
* deleting mongraph documents x 97.69 ops/sec ±10.57% (58 runs sampled)
* deleting mongraph documents + nodes async x 66.36 ops/sec ±1.82% (80 runs sampled)

**Fastest** is deleting native mongodb documents

**Slowest** is deleting mongraph documents + nodes async
```
